### PR TITLE
Change "on :local" to "run_locally" and change error class to trap for aws-cli

### DIFF
--- a/lib/capistrano/net_storage/s3/broker/aws_cli.rb
+++ b/lib/capistrano/net_storage/s3/broker/aws_cli.rb
@@ -15,7 +15,7 @@ class Capistrano::NetStorage::S3::Broker::AwsCLI < Capistrano::NetStorage::S3::B
   rescue SSHKit::StandardError
     c = config
     run_locally do
-      info "Archive is not found on #{c.archive_url}"
+      info "Archive is not found as #{c.archive_url}"
     end
   end
 

--- a/lib/capistrano/net_storage/s3/broker/aws_cli.rb
+++ b/lib/capistrano/net_storage/s3/broker/aws_cli.rb
@@ -14,7 +14,7 @@ class Capistrano::NetStorage::S3::Broker::AwsCLI < Capistrano::NetStorage::S3::B
     end
   rescue SSHKit::Runner::ExecuteError
     c = config
-    on :local do
+    run_locally do
       info "Archive is not found on #{c.archive_url}"
     end
   end
@@ -45,7 +45,7 @@ class Capistrano::NetStorage::S3::Broker::AwsCLI < Capistrano::NetStorage::S3::B
 
   def execute_aws_s3(cmd, *args)
     c = config
-    on :local do
+    run_locally do
       with(c.aws_environments) do
         execute :aws, 's3', cmd, *args
       end
@@ -54,7 +54,7 @@ class Capistrano::NetStorage::S3::Broker::AwsCLI < Capistrano::NetStorage::S3::B
 
   def capture_aws_s3(cmd, *args)
     c = config
-    on :local do
+    run_locally do
       with(c.aws_environments) do
         capture :aws, 's3', cmd, *args
       end

--- a/lib/capistrano/net_storage/s3/broker/aws_cli.rb
+++ b/lib/capistrano/net_storage/s3/broker/aws_cli.rb
@@ -12,7 +12,7 @@ class Capistrano::NetStorage::S3::Broker::AwsCLI < Capistrano::NetStorage::S3::B
     if capture_aws_s3('ls', config.archive_url)
       set :net_storage_uploaded_archive, true
     end
-  rescue SSHKit::Runner::ExecuteError
+  rescue SSHKit::StandardError
     c = config
     run_locally do
       info "Archive is not found on #{c.archive_url}"


### PR DESCRIPTION
Changes:

- `on :local` => `run_locally`. See https://github.com/DeNADev/capistrano-net_storage/pull/1
- `SSHKit::Runner::ExecuteError` => `SSHKit::StandardError`
  - Tha latter is the parent class of the former.
  - In some cases, the error class can be `SSHKit::Command::Failed`. And I want be more tolerant for variation of error type here.