### PR TITLE
Implement C::NS::S3::Broker::AwsCLI#cleanup to purge old archives on S3

### DIFF
--- a/lib/capistrano/net_storage/s3/config.rb
+++ b/lib/capistrano/net_storage/s3/config.rb
@@ -66,14 +66,30 @@ class Capistrano::NetStorage::S3
       end
     end
 
-    # S3 bucket URL via which one transports application archives
-    # @return [URI::Generic]
-    def bucket_url
+    # S3 bucket name via which one transports application archives
+    # @return [String]
+    def bucket
       @bucket ||= begin
         unless bucket = fetch(:net_storage_s3_bucket)
           raise Capistrano::NetStorage::S3::Error, ':net_storage_s3_bucket is not configured!'
         end
-        URI.parse("s3://#{bucket}")
+        bucket
+      end
+    end
+
+    # S3 bucket URL via which one transports application archives
+    # @return [URI::Generic]
+    def bucket_url
+      @bucket_url ||= URI.parse("s3://#{bucket}")
+    end
+
+    # Directory path on S3 bucket for application archives
+    # @return [String]
+    def archives_directory
+      # append '/' in case missing
+      @archives_directory ||= begin
+        dir = fetch(:net_storage_s3_archives_directory)
+        dir.sub(%r{[^/]\Z}, '\&/') if dir
       end
     end
 
@@ -105,17 +121,6 @@ class Capistrano::NetStorage::S3
     # @return [Fixnum]
     def max_retry
       @max_retry ||= fetch(:net_storage_s3_max_retry, 3)
-    end
-
-    private
-
-    # @return [String]
-    def archives_directory
-      # append '/' in case missing
-      @archives_directory ||= begin
-        dir = fetch(:net_storage_s3_archives_directory)
-        dir.sub(%r{[^/]\Z}, '\&/') if dir
-      end
     end
   end
 end

--- a/lib/capistrano/net_storage/s3/transport.rb
+++ b/lib/capistrano/net_storage/s3/transport.rb
@@ -7,7 +7,7 @@ require 'capistrano/net_storage/s3/config'
 
 class Capistrano::NetStorage::S3::Transport < Capistrano::NetStorage::Transport::Base
   extend Forwardable
-  def_delegators :broker, :check, :find_uploaded, :upload, :download
+  def_delegators :broker, :check, :find_uploaded, :upload, :download, :cleanup
 
   private
 

--- a/spec/capistrano/net_storage/s3/config_spec.rb
+++ b/spec/capistrano/net_storage/s3/config_spec.rb
@@ -16,6 +16,7 @@ describe Capistrano::NetStorage::S3::Config do
   describe 'Configuration params' do
     it 'Default parameters' do
       expect(config.broker).to be_an_instance_of Capistrano::NetStorage::S3::Broker::AwsCLI
+      expect { config.bucket }.to raise_error(Capistrano::NetStorage::S3::Error)
       expect { config.bucket_url }.to raise_error(Capistrano::NetStorage::S3::Error)
       expect(config.max_retry).to eq 3
 
@@ -44,7 +45,9 @@ describe Capistrano::NetStorage::S3::Config do
         current_revision: 'test-revision',
       }.each { |k, v| env.set k, v }
 
+      expect(config.bucket).to eq 'test-bucket'
       expect(config.bucket_url.to_s).to eq 's3://test-bucket'
+      expect(config.archives_directory).to eq 'archives/'
       expect(config.archives_url.to_s).to eq 's3://test-bucket/archives/'
       expect(config.archive_url.to_s).to eq "s3://test-bucket/archives/test-revision.#{net_storage.archive_suffix}"
       expect(config.max_retry).to eq 5


### PR DESCRIPTION
Using `aws s3api` command.

See also https://github.com/DeNADev/capistrano-net_storage/pull/2

### TODO

- Support aws-sdk