### PR TITLE
Add '--no-progress' option for upload / download

### DIFF
--- a/lib/capistrano/net_storage/s3/broker/aws_cli.rb
+++ b/lib/capistrano/net_storage/s3/broker/aws_cli.rb
@@ -25,7 +25,7 @@ class Capistrano::NetStorage::S3::Broker::AwsCLI < Capistrano::NetStorage::S3::B
     c  = config
     ns = net_storage
     Retryable.retryable(tries: c.max_retry, sleep: 0.1) do
-      execute_aws_s3('cp', ns.local_archive_path, c.archive_url)
+      execute_aws_s3('cp', '--no-progress', ns.local_archive_path, c.archive_url)
     end
   end
 
@@ -36,7 +36,7 @@ class Capistrano::NetStorage::S3::Broker::AwsCLI < Capistrano::NetStorage::S3::B
       Retryable.retryable(tries: c.max_retry, sleep: 0.1) do
         within releases_path do
           with(c.aws_environments) do
-            execute :aws, 's3', 'cp', c.archive_url, ns.archive_path
+            execute :aws, 's3', 'cp', '--no-progress', c.archive_url, ns.archive_path
           end
         end
       end


### PR DESCRIPTION
### Summary

Currently, the progress information floods the log file.
By specifying `--no-progress` option, we can avoid it.

### Other Information

### Checklist

* [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

