### PR TITLE
Prefer `require: false` for application loads

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ And Capistrano::NetStorage is a plugin of [Capistrano](http://capistranorb.com/)
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'capistrano-net_storage-s3'
+gem 'capistrano-net_storage-s3', require: false
 ```
 
 And then execute:


### PR DESCRIPTION
### Summary

As Capistrano::NetStorage::S3 is not required for Rails application,
it should not be loaded in application code.

`require: false` in Gemfile allows the above behavior.

### Other Information

### Checklist

* [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

